### PR TITLE
Create `lib.rs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod doldisasm;
+pub mod tracker;
+pub(crate) mod utils;
+pub mod symbol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
-mod doldisasm;
-mod tracker;
-mod utils;
-mod symbol;
+use dadosod::doldisasm;
 
 use argh::FromArgs;
 use doldisasm::DolCmd;


### PR DESCRIPTION
Allows usage of dadosod as a library. All modules except `utils` are exported.