### PR TITLE
Update ppc750cl again for more updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "ppc750cl"
 version = "0.2.0"
-source = "git+https://github.com/encounter/ppc750cl?branch=updates#20abce13e43f8d4ff4840732f9c92dda26ebe2ce"
+source = "git+https://github.com/encounter/ppc750cl?rev=4d8e4733319312abf47cde193d7386e55744bdf8#4d8e4733319312abf47cde193d7386e55744bdf8"
 dependencies = [
  "num-traits",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wii", "gamecube", "decompilation", "disassembly"]
 edition = "2021"
 
 [dependencies]
-ppc750cl = { git = 'https://github.com/encounter/ppc750cl', branch = 'updates', package = 'ppc750cl' }
+ppc750cl = { git = "https://github.com/encounter/ppc750cl", rev = "4d8e4733319312abf47cde193d7386e55744bdf8" }
 dol = { git = 'https://github.com/terorie/ppc750cl', package = 'dol' }
 serde = "1.0"
 csv = "1.1.6"

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -417,7 +417,7 @@ impl<'a> GPRTracker<'a> {
         let simple = ins.clone().simplified();
         let mut f = String::new();
 
-        write!(f, "{}{}", simple.mnemonic, ins.suffix())?;
+        write!(f, "{}{}", simple.mnemonic, simple.suffix)?;
         let mut writing_offset = false;
         for (i, arg) in simple.args.iter().enumerate() {
             if i == 0 {


### PR DESCRIPTION
Branch prediction bits are now supported on conditional branch instructions. The +/- suffix will only appear when the branch prediction bit is overridden from the default.

Adds more mnemonics for bd* and rlwinm. (Yay extrwi!)

Fixes incorrect outputs for crmove/crnot.

Changes can be viewed here: https://github.com/encounter/ppc750cl/commit/4d8e4733319312abf47cde193d7386e55744bdf8